### PR TITLE
Module/JLink Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,15 +44,15 @@ dependencies {
     implementation "eu.hansolo:toolboxfx:17.0.43"
     implementation "eu.hansolo.fx:heatmap:17.0.23"
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.2'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'
 }
 
 
 jar {
     from {
-        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-        configurations.runtimeClasspath.collect {  it.isDirectory() ? it : zipTree(it)  }
+        //duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        //configurations.runtimeClasspath.collect {  it.isDirectory() ? it : zipTree(it)  }
     } {
         exclude "META-INF/*.SF"
         exclude "META-INF/*.DSA"
@@ -73,7 +73,7 @@ jar {
                 'Bundle-License'        : 'https://www.apache.org/licenses/LICENSE-2.0;description=Apache License Version 2.0;link=https://spdx.org/licenses/Apache-2.0.html',
                 'Bundle-Description'    : description,
                 'Bundle-SymbolicName'   : 'eu.hansolo.fx.countries',
-                'Export-Package'        : 'eu.hansolo.fx.countries, eu.hansolo.fx.countries.evt, eu.hansolo.fx.countries.flag, eu.hansolo.fx.countries.font, eu.hansolo.fx.tools',
+                'Export-Package'        : 'eu.hansolo.fx.countries, eu.hansolo.fx.countries.evt, eu.hansolo.fx.countries.flag, eu.hansolo.fx.tools',
                 'Class-Path'            : "${project.name}-${project.version}.jar",
                 'Main-Class'            : 'eu.hansolo.fx.countries.Launcher'
         )
@@ -104,19 +104,11 @@ task DemoWorldPane(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
 }
 
-// create properties file including the version
-task createProperties(dependsOn: processResources) {
-    doLast {
-        new File("$buildDir//classes/java/main/eu/hansolo/fx/countries/version.properties").withWriter { w ->
-            Properties p = new Properties()
-            p['version'] = project.version.toString()
-            p.store w, null
-        }
+processResources {
+    def props = ["version": project.version.toString()]
+    filesMatching("**/eu/hansolo/fx/countries/version.properties") {
+        expand props
     }
-}
-
-classes {
-    dependsOn createProperties
 }
 
 run {

--- a/src/main/resources/eu/hansolo/fx/countries/version.properties
+++ b/src/main/resources/eu/hansolo/fx/countries/version.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-version=0
+version=${version}


### PR DESCRIPTION
This is a follow on to HanSolo/charts#109

This PR is 3/4 in an attempt to fix the following error I was getting when performing jlink of [Birdasaur/Trinity](https://github.com/Birdasaur/Trinity) with the latest charts (17.1.47). Realized this propagated from toolbox all the way to charts, so I apolize for the bunch of PR's. Note charts, countries were failing to jlink as well.

The error looked something like this, but it got better as I kept adding missing opens/exports:
```
Module eu.hansolo.fx.countries contains package eu.hansolo.toolboxfx, module eu.hansolo.toolboxfx exports package eu.hansolo.toolboxfx to eu.hansolo.fx.countries
```

Had to change a bit the current process resources approach to allow jlink to work once again as well. This helped remove the need to have a duplicate strategy since there would be no more "duplicates".

Edit (linking other PRs):
https://github.com/HanSolo/toolbox/pull/1
https://github.com/HanSolo/toolboxfx/pull/1
https://github.com/HanSolo/charts/pull/110
