### PR TITLE
streamline dependency/module graph

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,13 +39,11 @@ repositories {
 }
 
 dependencies {
+    api "eu.hansolo.fx:heatmap:17.0.25"
     implementation "org.openjfx:javafx-base:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-graphics:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-controls:${javafxVersion}:${platform}"
     implementation "org.openjfx:javafx-swing:${javafxVersion}:${platform}"
-    implementation "eu.hansolo:toolbox:17.0.55"
-    implementation "eu.hansolo:toolboxfx:17.0.45"
-    implementation "eu.hansolo.fx:heatmap:17.0.25"
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.3'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.3'

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -5,20 +5,18 @@ module eu.hansolo.fx.countries {
     requires java.desktop;
 
     // Java-FX
-    requires transitive javafx.base;
-    requires transitive javafx.graphics;
-    requires transitive javafx.controls;
-    requires transitive javafx.swing;
+    requires javafx.base;
+    requires javafx.graphics;
+    requires javafx.controls;
+    requires javafx.swing;
 
     // 3rd Party
-    requires transitive eu.hansolo.toolbox;
-    requires transitive eu.hansolo.toolboxfx;
     requires transitive eu.hansolo.fx.heatmap;
 
-    opens eu.hansolo.fx.countries to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap;
-    opens eu.hansolo.fx.countries.evt to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap;
-    opens eu.hansolo.fx.countries.flag to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap;
-    opens eu.hansolo.fx.countries.tools to eu.hansolo.toolbox, eu.hansolo.toolboxfx, eu.hansolo.fx.heatmap;
+    opens eu.hansolo.fx.countries to eu.hansolo.fx.heatmap;
+    opens eu.hansolo.fx.countries.evt to eu.hansolo.fx.heatmap;
+    opens eu.hansolo.fx.countries.flag to eu.hansolo.fx.heatmap;
+    opens eu.hansolo.fx.countries.tools to eu.hansolo.fx.heatmap;
 
     exports eu.hansolo.fx.countries;
     exports eu.hansolo.fx.countries.evt;


### PR DESCRIPTION
PR 3/4

This will help streamline the dependency graph across dependencies by using api configuration per gradle [docs](https://docs.gradle.org/current/userguide/java_library_plugin.html#declaring_module_dependencies).

This allows the end user to only have to type `implementation 'eu.hansolo.fx:countries:17.0.35'` to get all the needed dependencies.

![dg-countries](https://github.com/HanSolo/countries/assets/3933065/aa0087fe-1484-43fc-9189-4e16b5d65ace)

Note: CI will fail until a release of `heatmap` is made after https://github.com/HanSolo/heatmap/pull/2