### PR TITLE
Missing description and cleanup deprecations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ jar {
                 'Implementation-Version': project.version,
                 'Bundle-Name'           : project.name,
                 'Bundle-License'        : 'https://www.apache.org/licenses/LICENSE-2.0;description=Apache License Version 2.0;link=https://spdx.org/licenses/Apache-2.0.html',
-                'Bundle-Description'    : description,
+                'Bundle-Description'    : project.description,
                 'Bundle-SymbolicName'   : 'eu.hansolo.fx.countries',
                 'Export-Package'        : 'eu.hansolo.fx.countries, eu.hansolo.fx.countries.evt, eu.hansolo.fx.countries.flag, eu.hansolo.fx.tools',
                 'Class-Path'            : "${project.name}-${project.version}.jar",

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ dependencies {
 }
 
 application {
-    mainClass = "eu.hansolo.fx.countries.Launcher"
+    mainClass = "eu.hansolo.fx.countries.LauncherDemoWorldPane"
     mainModule = moduleName
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
 description   = 'Countries is a JavaFX library containing controls and info for countries and cities'
-mainClassName = "$moduleName/eu.hansolo.fx.countries.Launcher" // Deprecated: Old Gradle 6.4 Syntax
 
 Date buildTimeAndDate = new Date()
 ext {
@@ -124,6 +123,7 @@ processResources {
 }
 
 run {
+    def mainClassName = moduleName + "/" + application.mainClass.get()
     inputs.property("moduleName", moduleName)
     doFirst {
         jvmArgs = [


### PR DESCRIPTION
The manifest would look like this for the description: `Bundle-Description: Assembles a jar archive containing the classes of the 'main' feature.`

The main class also pointed to a Launcher that did not exists, so I updated it to point to `LauncherDemoWorldPane`.

Lastly, removed the deprecated `mainClassName` entry since latest published jars are confirmed to be working without using it.